### PR TITLE
Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.9</version>
         </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.11</version>
+            <version>1.15</version>
             <scope>compile</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -198,13 +198,13 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>5.0.0</version>
+            <version>5.2.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.poi/poi-scratchpad -->
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-scratchpad</artifactId>
-            <version>5.0.0</version>
+            <version>5.2.2</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.jsoup/jsoup -->

--- a/pom.xml
+++ b/pom.xml
@@ -189,12 +189,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
-        </dependency>
-
-        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>3.12.0</version>
         </dependency>
 
         <!-- 日志包-->

--- a/src/main/java/net/diaowen/dwsurvey/service/impl/UserManagerImpl.java
+++ b/src/main/java/net/diaowen/dwsurvey/service/impl/UserManagerImpl.java
@@ -6,7 +6,6 @@ import java.util.List;
 import net.diaowen.common.plugs.httpclient.HttpResult;
 import net.diaowen.dwsurvey.service.UserManager;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.poi.util.SystemOutLogger;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
In this pr, I upgraded some dependencies, and to avoid some vulnerabilities.

- Remove duplicated `commons-lang3` dependency
- Bump `commons-codec` from 1.11 to 1.15
- Bump `poi` from 5.0.0 to 5.2.2
- Bump `logback` from 1.2.3 to 1.2.9
- Bump `commons-lang3` from 3.4 to 3.12.0