### PR TITLE
Integration Casdoor SSO login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -331,6 +331,11 @@
             <version>1.21</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.casbin</groupId>
+            <artifactId>casdoor-spring-boot-starter</artifactId>
+            <version>1.3.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,11 @@
             <artifactId>casdoor-spring-boot-starter</artifactId>
             <version>1.3.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.casbin</groupId>
+            <artifactId>shiro-casdoor</artifactId>
+            <version>1.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/net/diaowen/common/base/controller/LoginRegisterResult.java
+++ b/src/main/java/net/diaowen/common/base/controller/LoginRegisterResult.java
@@ -1,7 +1,6 @@
 package net.diaowen.common.base.controller;
 
 import net.diaowen.common.plugs.httpclient.HttpResult;
-import net.sf.json.JSON;
 
 public class LoginRegisterResult {
 
@@ -9,6 +8,7 @@ public class LoginRegisterResult {
     private String type;
     private String[] currentAuthority;
     private HttpResult httpResult;
+    private String username;
 
     public String getStatus() {
         return status;
@@ -42,7 +42,15 @@ public class LoginRegisterResult {
         this.httpResult = httpResult;
     }
 
-    public static LoginRegisterResult RESULT(String status,String type){
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public static LoginRegisterResult RESULT(String status, String type){
         LoginRegisterResult loginResult = new LoginRegisterResult();
         loginResult.setStatus(status);
         loginResult.setType(type);
@@ -50,19 +58,21 @@ public class LoginRegisterResult {
         return loginResult;
     }
 
-    public static LoginRegisterResult SUCCESS(String currentAuthority){
+    public static LoginRegisterResult SUCCESS(String currentAuthority, String username) {
         LoginRegisterResult loginResult = new LoginRegisterResult();
         loginResult.setStatus("ok");
         loginResult.setType("account");
+        loginResult.setUsername(username);
 //        loginResult.setCurrentAuthority("admin");
         loginResult.setCurrentAuthority(new String[]{currentAuthority});
         return loginResult;
     }
 
-    public static LoginRegisterResult SUCCESS(String[] currentAuthority){
+    public static LoginRegisterResult SUCCESS(String[] currentAuthority, String username) {
         LoginRegisterResult loginResult = new LoginRegisterResult();
         loginResult.setStatus("ok");
         loginResult.setType("account");
+        loginResult.setUsername(username);
 //        loginResult.setCurrentAuthority("admin");
         loginResult.setCurrentAuthority(currentAuthority);
         return loginResult;

--- a/src/main/java/net/diaowen/common/base/entity/User.java
+++ b/src/main/java/net/diaowen/common/base/entity/User.java
@@ -1,21 +1,10 @@
 package net.diaowen.common.base.entity;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-
-
-import net.diaowen.common.plugs.mapper.CollectionMapper;
+import java.util.Date;
 
 /**
  *
@@ -66,6 +55,7 @@ public class User extends IdEntity {
 
 	private String wxOpenId;
 	private String sessionId;
+	private String casdoorId;
 
 	// Hibernate自动维护的Version字段
 	// @Version
@@ -256,7 +246,16 @@ public class User extends IdEntity {
 		this.sessionId = sessionId;
 	}
 
+	public String getCasdoorId() {
+		return casdoorId;
+	}
+
+	public void setCasdoorId(String casdoorId) {
+		this.casdoorId = casdoorId;
+	}
+
 	private String plainPassword;
+
 	@Transient
 	public String getPlainPassword() {
 		return plainPassword;

--- a/src/main/java/net/diaowen/common/base/service/AccountManager.java
+++ b/src/main/java/net/diaowen/common/base/service/AccountManager.java
@@ -134,6 +134,11 @@ public class AccountManager {
 		return user;
 	}
 
+	@Transactional(readOnly = true)
+	public User findUserByCasdoorId(String casdoorId) {
+		return userDao.findUniqueBy("casdoorId", casdoorId);
+	}
+
 	/*验证邮箱是否存在*/
 	@Transactional(readOnly = true)
 	public User findUserByEmail(String email){

--- a/src/main/java/net/diaowen/dwsurvey/config/DWSurveyConfig.java
+++ b/src/main/java/net/diaowen/dwsurvey/config/DWSurveyConfig.java
@@ -24,7 +24,7 @@ public class DWSurveyConfig {
     public static String DWSURVEY_WEB_INFO_SITE_ICP = null;
     public static String DWSURVEY_WEB_INFO_SITE_MAIL = null;
     public static String DWSURVEY_WEB_INFO_SITE_PHONE = null;
-    public static String DWSURVEY_OATH_TYPE = null;
+    public static String DWSURVEY_OAUTH_TYPE = null;
 
     @Value("${dwsurvey.web.file-path}")
     public void setWebFilePath(String webFilePath) {
@@ -104,6 +104,6 @@ public class DWSurveyConfig {
     @Value("${dwsurvey.web.info.site-phone}")
     public void setDwsurveyWebInfoSitePhone(String dwsurveyWebInfoSitePhone) { DWSURVEY_WEB_INFO_SITE_PHONE = dwsurveyWebInfoSitePhone; }
 
-    @Value("${dwsurvey.oath.type}")
-    public void setDwsurveyOathType(String dwsurveyOathType) { DWSURVEY_OATH_TYPE = dwsurveyOathType; }
+    @Value("${dwsurvey.oauth.type}")
+    public void setDwsurveyOathType(String dwsurveyOathType) { DWSURVEY_OAUTH_TYPE = dwsurveyOathType; }
 }

--- a/src/main/java/net/diaowen/dwsurvey/config/DWSurveyConfig.java
+++ b/src/main/java/net/diaowen/dwsurvey/config/DWSurveyConfig.java
@@ -104,6 +104,6 @@ public class DWSurveyConfig {
     @Value("${dwsurvey.web.info.site-phone}")
     public void setDwsurveyWebInfoSitePhone(String dwsurveyWebInfoSitePhone) { DWSURVEY_WEB_INFO_SITE_PHONE = dwsurveyWebInfoSitePhone; }
 
-    @Value("${dwsurvey.oauth.type}")
+    @Value("${dwsurvey.oauth.type:built-in}")
     public void setDwsurveyOathType(String dwsurveyOathType) { DWSURVEY_OAUTH_TYPE = dwsurveyOathType; }
 }

--- a/src/main/java/net/diaowen/dwsurvey/config/DWSurveyConfig.java
+++ b/src/main/java/net/diaowen/dwsurvey/config/DWSurveyConfig.java
@@ -24,7 +24,7 @@ public class DWSurveyConfig {
     public static String DWSURVEY_WEB_INFO_SITE_ICP = null;
     public static String DWSURVEY_WEB_INFO_SITE_MAIL = null;
     public static String DWSURVEY_WEB_INFO_SITE_PHONE = null;
-
+    public static String DWSURVEY_OATH_TYPE = null;
 
     @Value("${dwsurvey.web.file-path}")
     public void setWebFilePath(String webFilePath) {
@@ -103,4 +103,7 @@ public class DWSurveyConfig {
 
     @Value("${dwsurvey.web.info.site-phone}")
     public void setDwsurveyWebInfoSitePhone(String dwsurveyWebInfoSitePhone) { DWSURVEY_WEB_INFO_SITE_PHONE = dwsurveyWebInfoSitePhone; }
+
+    @Value("${dwsurvey.oath.type}")
+    public void setDwsurveyOathType(String dwsurveyOathType) { DWSURVEY_OATH_TYPE = dwsurveyOathType; }
 }

--- a/src/main/java/net/diaowen/dwsurvey/config/ShiroConfig.java
+++ b/src/main/java/net/diaowen/dwsurvey/config/ShiroConfig.java
@@ -49,14 +49,10 @@ public class ShiroConfig {
 
     //权限管理，配置主要是Realm的管理认证  SecurityManager
     @Bean
-    public DefaultWebSecurityManager securityManager(@Value("${dwsurvey.oauth.type:built-in}") String oauthType) {
+    public DefaultWebSecurityManager securityManager() {
         DefaultWebSecurityManager securityManager = new DefaultWebSecurityManager();
-        if (oauthType.equals("casdoor")) {
-            securityManager.setRealm(casdoorShiroRealm());
-        } else {
-            securityManager.setRealm(shiroDbRealm());
-            securityManager.setRememberMeManager(rememberMeManager());
-        }
+        securityManager.setRealm(shiroDbRealm());
+        securityManager.setRememberMeManager(rememberMeManager());
         return securityManager;
     }
 

--- a/src/main/java/net/diaowen/dwsurvey/controller/DwWebController.java
+++ b/src/main/java/net/diaowen/dwsurvey/controller/DwWebController.java
@@ -3,18 +3,16 @@ package net.diaowen.dwsurvey.controller;
 import net.diaowen.common.base.entity.User;
 import net.diaowen.common.base.service.AccountManager;
 import net.diaowen.common.plugs.httpclient.HttpResult;
-import net.diaowen.common.plugs.httpclient.HttpStatus;
 import net.diaowen.dwsurvey.common.FooterInfo;
 import net.diaowen.dwsurvey.config.DWSurveyConfig;
 import net.diaowen.dwsurvey.entity.SurveyDirectory;
-import org.apache.commons.lang.time.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -57,5 +55,9 @@ public class DwWebController {
         return HttpResult.FAILURE();
     }
 
-
+    @GetMapping("/oauth-type.do")
+    @ResponseBody
+    public HttpResult<String> oauthType() {
+        return HttpResult.SUCCESS(DWSurveyConfig.DWSURVEY_OAUTH_TYPE);
+    }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -34,7 +34,7 @@ dwsurvey:
     info: DWSurvey OSS V5.2.6 Boot
     number: OSS V5.2.6
     built: 2022/03/17
-  oath:
+  oauth:
     type: built-in
 # 服务占用的端口号
 server:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -34,6 +34,8 @@ dwsurvey:
     info: DWSurvey OSS V5.2.6 Boot
     number: OSS V5.2.6
     built: 2022/03/17
+  oath:
+    type: built-in
 # 服务占用的端口号
 server:
   port: 8080
@@ -122,3 +124,11 @@ logging:
     org:
       hibernate: ERROR
       apache: ERROR
+# Casdoor SSO 配置
+casdoor:
+  endpoint:
+  client-id:
+  client-secret:
+  certificate:
+  organization-name:
+  application-name:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -22,7 +22,7 @@ dwsurvey:
     info: DWSurvey OSS V5.2.6 Boot
     number: OSS V5.2.6
     built: 2022/03/17
-  oath:
+  oauth:
     type: built-in
 server:
   port: 8080

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -22,6 +22,8 @@ dwsurvey:
     info: DWSurvey OSS V5.2.6 Boot
     number: OSS V5.2.6
     built: 2022/03/17
+  oath:
+    type: built-in
 server:
   port: 8080
 
@@ -98,3 +100,11 @@ logging:
     org:
       hibernate: ERROR
       apache: ERROR
+# Casdoor SSO 配置
+casdoor:
+  endpoint:
+  client-id:
+  client-secret:
+  certificate:
+  organization-name:
+  application-name:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -22,7 +22,7 @@ dwsurvey:
     info: DWSurvey OSS V5.2.5 Boot
     number: OSS V5.2.5
     built: 2021/11/21
-  oath:
+  oauth:
     type: built-in
 server:
   port: 8080

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -22,6 +22,8 @@ dwsurvey:
     info: DWSurvey OSS V5.2.5 Boot
     number: OSS V5.2.5
     built: 2021/11/21
+  oath:
+    type: built-in
 server:
   port: 8080
 
@@ -98,3 +100,11 @@ logging:
     org:
       hibernate: ERROR
       apache: ERROR
+# Casdoor SSO 配置
+casdoor:
+  endpoint:
+  client-id:
+  client-secret:
+  certificate:
+  organization-name:
+  application-name:

--- a/src/main/resources/conf/sql/dwsurvey.sql
+++ b/src/main/resources/conf/sql/dwsurvey.sql
@@ -788,6 +788,7 @@ CREATE TABLE `t_user` (
   `visibility` int(11) DEFAULT NULL,
   `wwwooo` varchar(255) DEFAULT NULL,
   `wx_open_id` varchar(255) DEFAULT NULL,
+  `casdoor_id` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `login_name` (`login_name`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
@@ -796,7 +797,7 @@ CREATE TABLE `t_user` (
 --  Records of `t_user`
 -- ----------------------------
 BEGIN;
-INSERT INTO `t_user` VALUES ('1', null, '2013-03-21 21:15:21', null, null, '2013-03-21 21:15:21', '1', 'service@diaowen.net', null, null, '2021-12-31 09:46:37', 'dwsurvey', '柯远', null, '1', '7c4a8d09ca3762af61e59520943dc26494f8941b', '2', '1', null, null, null, null, null, null);
+INSERT INTO `t_user` VALUES ('1', null, '2013-03-21 21:15:21', null, null, '2013-03-21 21:15:21', '1', 'service@diaowen.net', null, null, '2021-12-31 09:46:37', 'dwsurvey', '柯远', null, '1', '7c4a8d09ca3762af61e59520943dc26494f8941b', '2', '1', null, null, null, null, null, null, null);
 COMMIT;
 
 -- ----------------------------


### PR DESCRIPTION
I introduced [Casdoor](http://casdoor.org/) SSO login to DWSurvey.

To use built-in login type, we can set `dwsurvey.oauth.type` to `built-in`, which is by default.
To use Casdoor login type, set `dwsurvey.oauth.type` to `casdoor` and set `casdoor` configuration.

It did not discard the built-in login system. When logging in with Casdoor for the first time, it will create a user, email for the username and `casdoor_user` for the password. So it is easy to use back to the built-in login system.

Front-end code: [https://github.com/wkeyuan/DWSurvey_Vue/pull/1](https://github.com/wkeyuan/DWSurvey_Vue/pull/1)