### PR TITLE
fix(sec): upgrade org.apache.poi:poi-scratchpad to 5.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-scratchpad</artifactId>
-            <version>5.0.0</version>
+            <version>5.2.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.jsoup/jsoup -->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.poi:poi-scratchpad 5.0.0
- [CVE-2022-26336](https://www.oscs1024.com/hd/CVE-2022-26336)


### What did I do？
Upgrade org.apache.poi:poi-scratchpad from 5.0.0 to 5.2.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS